### PR TITLE
Add backend unit tests

### DIFF
--- a/internal/domain/default_test.go
+++ b/internal/domain/default_test.go
@@ -1,0 +1,66 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/robstave/meowmorize/internal/domain/types"
+	"github.com/robstave/meowmorize/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCreateDefaultDeck_WithData(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	var savedDeck types.Deck
+	deckRepo.On("CreateDeck", mock.AnythingOfType("types.Deck")).Return(nil).Run(func(args mock.Arguments) {
+		savedDeck = args.Get(0).(types.Deck)
+	})
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	deck, err := s.CreateDefaultDeck(true, "user1")
+	assert.NoError(t, err)
+	assert.Equal(t, "user1", deck.UserID)
+	assert.Len(t, deck.Cards, 2)
+	assert.Equal(t, deck.Name, "Default Deck")
+	assert.Equal(t, savedDeck.UserID, "user1")
+	assert.Len(t, savedDeck.Cards, 2)
+	deckRepo.AssertExpectations(t)
+}
+
+func TestCreateDefaultDeck_NoData(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	var savedDeck types.Deck
+	deckRepo.On("CreateDeck", mock.AnythingOfType("types.Deck")).Return(nil).Run(func(args mock.Arguments) {
+		savedDeck = args.Get(0).(types.Deck)
+	})
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	deck, err := s.CreateDefaultDeck(false, "user2")
+	assert.NoError(t, err)
+	assert.Equal(t, "user2", deck.UserID)
+	assert.Len(t, deck.Cards, 0)
+	assert.Len(t, savedDeck.Cards, 0)
+	deckRepo.AssertExpectations(t)
+}
+
+func TestCreateDefaultDeck_Error(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	deckRepo.On("CreateDeck", mock.AnythingOfType("types.Deck")).Return(errors.New("fail"))
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	deck, err := s.CreateDefaultDeck(false, "user3")
+	assert.Error(t, err)
+	assert.Empty(t, deck.ID)
+	deckRepo.AssertExpectations(t)
+}

--- a/internal/domain/default_test.go
+++ b/internal/domain/default_test.go
@@ -61,6 +61,6 @@ func TestCreateDefaultDeck_Error(t *testing.T) {
 	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
 	deck, err := s.CreateDefaultDeck(false, "user3")
 	assert.Error(t, err)
-	assert.Empty(t, deck.ID)
+	assert.NotEmpty(t, deck.ID)
 	deckRepo.AssertExpectations(t)
 }

--- a/internal/domain/llm_test.go
+++ b/internal/domain/llm_test.go
@@ -1,0 +1,64 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/robstave/meowmorize/internal/adapters/repositories/mocks"
+	"github.com/robstave/meowmorize/internal/domain/types"
+	"github.com/robstave/meowmorize/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetExplanation(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+
+	// Seed user expectation
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	llmRepo.On("RunPrompt", mock.Anything, "test prompt").Return("answer", nil)
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	resp, err := s.GetExplanation("test prompt")
+	assert.NoError(t, err)
+	assert.Equal(t, "answer", resp)
+	llmRepo.AssertExpectations(t)
+}
+
+func TestGetExplanation_Error(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	llmRepo.On("RunPrompt", mock.Anything, "bad prompt").Return("", errors.New("fail"))
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	resp, err := s.GetExplanation("bad prompt")
+	assert.Error(t, err)
+	assert.Equal(t, "", resp)
+	llmRepo.AssertExpectations(t)
+}
+
+func TestIsLLMAvailable(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	// LLM not initialized
+	llmRepo.On("RunPrompt", mock.Anything, "test").Return("", types.ErrLLMNotInitialized)
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	assert.False(t, s.IsLLMAvailable())
+
+	// LLM initialized and returns without error
+	llmRepo.ExpectedCalls = nil
+	llmRepo.On("RunPrompt", mock.Anything, "test").Return("ok", nil)
+	assert.True(t, s.IsLLMAvailable())
+
+	// Service with nil repo
+	sNil := &Service{}
+	assert.False(t, sNil.IsLLMAvailable())
+}

--- a/internal/domain/llm_test.go
+++ b/internal/domain/llm_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/robstave/meowmorize/internal/adapters/repositories/mocks"
 	"github.com/robstave/meowmorize/internal/domain/types"
 	"github.com/robstave/meowmorize/internal/logger"
 	"github.com/stretchr/testify/assert"

--- a/internal/domain/session_test.go
+++ b/internal/domain/session_test.go
@@ -120,6 +120,11 @@ func TestAdjustSession_Success(t *testing.T) {
 	deckRepo.On("GetDeckByID", deckID).Return(deck, nil)
 	deckRepo.On("UpdateDeck", mock.AnythingOfType("types.Deck")).Return(nil)
 
+	// Expect session log creation
+	sessionRepo.On("CreateLog", mock.MatchedBy(func(log types.SessionLog) bool {
+		return log.DeckID == deckID && log.CardID == "card1" && log.Action == string(types.IncrementPass)
+	})).Return(nil)
+
 	// Initialize service.
 	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
 

--- a/internal/domain/stats_test.go
+++ b/internal/domain/stats_test.go
@@ -1,0 +1,53 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/robstave/meowmorize/internal/domain/types"
+	"github.com/robstave/meowmorize/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestClearDeckStats_Success(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	deck := types.Deck{ID: "deck1", Cards: []types.Card{{ID: "card1", PassCount: 2, FailCount: 1, SkipCount: 1}}}
+	deckRepo.On("GetDeckByID", "deck1").Return(deck, nil)
+	cardRepo.On("UpdateCard", mock.MatchedBy(func(c types.Card) bool {
+		return c.ID == "card1" && c.PassCount == 0 && c.FailCount == 0 && c.SkipCount == 0
+	})).Return(nil)
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	s.sessions["deck1"] = &types.Session{
+		DeckID:    "deck1",
+		CardStats: []types.CardStats{{CardID: "card1", Viewed: true, Skipped: true}},
+		Stats:     types.SessionStats{TotalCards: 1, ViewedCount: 1, Remaining: 0, CurrentIndex: 1},
+	}
+
+	err := s.ClearDeckStats("deck1", true, true)
+	assert.NoError(t, err)
+	sess := s.sessions["deck1"]
+	assert.False(t, sess.CardStats[0].Viewed)
+	assert.False(t, sess.CardStats[0].Skipped)
+	assert.Equal(t, 0, sess.Stats.ViewedCount)
+	assert.Equal(t, 1, sess.Stats.Remaining)
+	cardRepo.AssertExpectations(t)
+	deckRepo.AssertExpectations(t)
+}
+
+func TestClearDeckStats_GetDeckError(t *testing.T) {
+	cardRepo, userRepo, deckRepo, sessionRepo := setupRepositories()
+	llmRepo := setupLLMRepository()
+	userRepo.On("GetUserByUsername", "meow").Return(&types.User{ID: "dummy", Username: "meow"}, nil)
+
+	deckRepo.On("GetDeckByID", "bad").Return(types.Deck{}, errors.New("not found"))
+
+	s := NewService(logger.InitializeLogger(), deckRepo, cardRepo, userRepo, sessionRepo, llmRepo)
+	err := s.ClearDeckStats("bad", true, true)
+	assert.Error(t, err)
+	deckRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- add unit tests for LLM service logic
- add unit tests for creating the default deck
- add unit tests for clearing deck stats

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684359d92e54832ebfe2bf54c80ea945