### PR TITLE
Improve import deck workflow

### DIFF
--- a/meowmorize-frontend/src/pages/ImportPage.jsx
+++ b/meowmorize-frontend/src/pages/ImportPage.jsx
@@ -47,15 +47,17 @@ const ImportPage = () => {
   });
   const { loadDecks } = useContext(DeckContext);
 
-  const handleFileChange = (event) => {
+  const handleFileSelect = async (event) => {
     const file = event.target.files[0];
+    if (!file) return;
     setSelectedFile(file);
     setMessage({ type: '', text: '' });
     setSnackbar({ open: false, message: '', severity: 'success' });
+    await handleImport(file);
   };
 
-  const handleImport = async () => {
-    if (!selectedFile) {
+  const handleImport = async (file = selectedFile) => {
+    if (!file) {
       setMessage({ type: 'error', text: 'Please select a file to import.' });
       setSnackbar({
         open: true,
@@ -65,7 +67,7 @@ const ImportPage = () => {
       return;
     }
 
-    const fileName = selectedFile.name.toLowerCase();
+    const fileName = file.name.toLowerCase();
     setLoading(true);
     setMessage({ type: '', text: '' });
 
@@ -73,7 +75,7 @@ const ImportPage = () => {
       // JSON Import: Send the file to your JSON import API
       if (fileName.endsWith('.json')) {
         const formData = new FormData();
-        formData.append('deck_file', selectedFile);
+        formData.append('deck_file', file);
         const response = await importDeck(formData);
         // If a custom title was provided, update the deck
         if (deckTitle.trim() !== 'Default Deck') {
@@ -95,7 +97,7 @@ const ImportPage = () => {
         fileName.endsWith('.markdown') ||
         fileName.endsWith('.txt')
       ) {
-        const text = await selectedFile.text();
+        const text = await file.text();
         const cards = parseMarkdownToCards(text);
         if (cards.length === 0) {
           setMessage({
@@ -188,30 +190,18 @@ const ImportPage = () => {
             variant="contained"
             component="label"
             startIcon={<UploadFileIcon />}
+            disabled={loading}
           >
-            Choose File
+            {loading ? <CircularProgress size={24} /> : 'Import Deck'}
             <input
               type="file"
               accept=".json,.md,.markdown,.txt"
               hidden
-              onChange={handleFileChange}
+              onChange={handleFileSelect}
             />
           </Button>
         </Tooltip>
-        {selectedFile && (
-          <Typography variant="body1">
-            Selected File: {selectedFile.name}
-          </Typography>
-        )}
         {message.text && <Alert severity={message.type}>{message.text}</Alert>}
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleImport}
-          disabled={loading}
-        >
-          {loading ? <CircularProgress size={24} /> : 'Import Deck'}
-        </Button>
       </Box>
       {/* Optionally include additional instructions via Accordion */}
       <Box sx={{ mt: 4 }}>

--- a/meowmorize-frontend/src/pages/jsonInstructions.js
+++ b/meowmorize-frontend/src/pages/jsonInstructions.js
@@ -1,7 +1,10 @@
 const jsonInstructions = `
-The app imports and exports in a JSON format. This is a more native format that preserves title, description, metrics, and stars.
+**JSON Format**
 
-_Note:_ This app may undergo some changes as we plan to decouple cards from decks.
+- Use this when you want to preserve deck titles, descriptions and statistics.
+- Files exported from MeowMorize already follow this structure.
+
+_Note:_ Future versions may decouple cards from decks.
 `;
 
 export default jsonInstructions;

--- a/meowmorize-frontend/src/pages/markdownInstructions.js
+++ b/meowmorize-frontend/src/pages/markdownInstructions.js
@@ -1,47 +1,20 @@
 const markdownInstructions = `
-# Markdown format
+**Markdown Format**
 
-The markdown format is a pretty simple combination of comments and headers that chats can easily produce.
-The file should be saved as .txt or .md
+1. Wrap each card with <!-- Card Start --> and <!-- Card End -->.
+2. Use \`### Front\` for the question and \`### Back\` for the answer.
+3. Save the file with a ".md" or ".txt" extension.
 
-
-## Markdown Create Prompt V2.0
-
-Create a set of educational flashcards in Markdown format using the following structure.
-
-Each card must be wrapped in HTML comments:
+Example:
 
 \`\`\`
 <!-- Card Start -->
-
-[card content]
-
-<!-- Card End -->
-\`\`\`
-
-For each card:
-
-1. **Front side:** Begins with \`### Front\` followed by the front text in Markdown.
-2. **Back side:** Begins with \`### Back\` followed by the back text.
-3. Use standard Markdown formatting (bold, images, etc.) within the content.
-
-**Example card format:**
-
-\`\`\`
-<!-- Card Start -->
-
 ### Front
-
 Question here
-
 ### Back
-
 Answer here
-
 <!-- Card End -->
 \`\`\`
-
-Please create the flashcards directly in this format.  Do not change the number of ###.  it must be exactly 3 ### for the front and 3 ### for the back.
 `;
 
 export default markdownInstructions;


### PR DESCRIPTION
## Summary
- combine file selection and import into a single button
- clean up JSON/Markdown help text

## Testing
- `npm test --prefix meowmorize-frontend` *(fails: react-scripts not found)*
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68477938b5ec832eb24949622e8153e3