### PR TITLE
Add role field to user model

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ docker run -d \
   -e DB_PATH=/app/data/db.sqlite3 \
   -e DEFAULT_USER_USERNAME=mycustomuser \
   -e DEFAULT_USER_PASSWORD=mycustompass \
+  -e DEFAULT_USER_ROLE=mycustomrole \
   rstave/meowmorize:latest
 ```
 
@@ -457,7 +458,7 @@ Ensure all dependencies are installed and run the following commands using the h
 
 - **Database Reset**: To start fresh, simply delete the `meowmorize.db` file located at the root directory and restart the backend application.
 - **Ports Configuration**: The frontend listens on port `8999` as specified in the `.env` file. Ensure this port is available or adjust the configuration as needed.
-- **User Authentication**: The application initializes with a default user. Ensure to secure and manage user credentials appropriately.
+- **User Authentication**: The application initializes with a default user. Customize the username, password, and role using the `DEFAULT_USER_USERNAME`, `DEFAULT_USER_PASSWORD`, and `DEFAULT_USER_ROLE` environment variables (role defaults to `admin`).
 
 ## License
 

--- a/internal/adapters/controller/auth.go
+++ b/internal/adapters/controller/auth.go
@@ -72,6 +72,7 @@ func (hc *MeowController) Login(c echo.Context) error {
 	claims := token.Claims.(jwt.MapClaims)
 
 	claims["username"] = user.Username
+	claims["role"] = user.Role
 	claims["exp"] = time.Now().Add(time.Hour * 72).Unix() // Token expires after 72 hours
 
 	t, err := token.SignedString(JWTSecret)

--- a/internal/domain/seeder.go
+++ b/internal/domain/seeder.go
@@ -20,6 +20,10 @@ func (s *Service) SeedUser() error {
 	if defaultPassword == "" {
 		defaultPassword = "meow"
 	}
+	defaultRole := os.Getenv("DEFAULT_USER_ROLE")
+	if defaultRole == "" {
+		defaultRole = "admin"
+	}
 
 	// Check if the user already exists
 	existingUser, err := s.userRepo.GetUserByUsername(defaultUsername)
@@ -42,6 +46,7 @@ func (s *Service) SeedUser() error {
 		ID:       uuid.New().String(),
 		Username: defaultUsername,
 		Password: string(hashedPassword),
+		Role:     defaultRole,
 	}
 
 	if err := s.userRepo.CreateUser(user); err != nil {

--- a/internal/domain/types/user.go
+++ b/internal/domain/types/user.go
@@ -9,6 +9,7 @@ type User struct {
 	ID        string    `gorm:"primaryKey" json:"id"`
 	Username  string    `gorm:"uniqueIndex;size:100;not null" json:"username"`
 	Password  string    `gorm:"size:255;not null" json:"-"`
+	Role      string    `gorm:"size:50;default:user" json:"role"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary
- add `Role` to `User` model
- allow configuring default role via `DEFAULT_USER_ROLE`
- include role claim in JWT tokens
- document default role in README

## Testing
- `./helper test` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6847cc2c4488832ebdb9a547496a9305