### PR TITLE
Add user account menu with password change

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -142,6 +142,9 @@ func main() {
 	// Get distinct session log IDs for a user (optionally by deck):
 	protectedSessionGroup.GET("/ids", meowController.GetSessionLogIds)
 
+	userGroup := api.Group("/user", jwtMiddleware)
+	userGroup.PUT("/password", meowController.ChangePassword)
+
 	adminGroup.GET("/users", meowController.AdminGetAllUsers)
 	adminGroup.POST("/users", meowController.AdminCreateUser)
 	adminGroup.DELETE("/users/:id", meowController.AdminDeleteUser)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -85,7 +85,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/types.User"
+                            "$ref": "#/definitions/controller.AdminCreateUserRequest"
                         }
                     }
                 ],
@@ -1708,9 +1708,92 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/user/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the authenticated user's password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Change user password",
+                "parameters": [
+                    {
+                        "description": "New password",
+                        "name": "password",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.ChangePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "controller.AdminCreateUserRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "controller.CardContentReq": {
             "type": "object",
             "required": [
@@ -1750,6 +1833,14 @@ const docTemplate = `{
                 "value": {
                     "description": "Used only for SetStars",
                     "type": "integer"
+                }
+            }
+        },
+        "controller.ChangePasswordRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -77,7 +77,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/types.User"
+                            "$ref": "#/definitions/controller.AdminCreateUserRequest"
                         }
                     }
                 ],
@@ -1700,9 +1700,92 @@
                     }
                 }
             }
+        },
+        "/user/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the authenticated user's password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Change user password",
+                "parameters": [
+                    {
+                        "description": "New password",
+                        "name": "password",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controller.ChangePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "controller.AdminCreateUserRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "controller.CardContentReq": {
             "type": "object",
             "required": [
@@ -1742,6 +1825,14 @@
                 "value": {
                     "description": "Used only for SetStars",
                     "type": "integer"
+                }
+            }
+        },
+        "controller.ChangePasswordRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,14 @@
 basePath: /api
 definitions:
+  controller.AdminCreateUserRequest:
+    properties:
+      password:
+        type: string
+      role:
+        type: string
+      username:
+        type: string
+    type: object
   controller.CardContentReq:
     properties:
       text:
@@ -29,6 +38,11 @@ definitions:
     required:
     - action
     - card_id
+    type: object
+  controller.ChangePasswordRequest:
+    properties:
+      password:
+        type: string
     type: object
   controller.ClearDeckStatsRequest:
     properties:
@@ -316,7 +330,7 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/types.User'
+          $ref: '#/definitions/controller.AdminCreateUserRequest'
       produces:
       - application/json
       responses:
@@ -1366,6 +1380,50 @@ paths:
       summary: Get session statistics
       tags:
       - Sessions
+  /user/password:
+    put:
+      consumes:
+      - application/json
+      description: Update the authenticated user's password
+      parameters:
+      - description: New password
+        in: body
+        name: password
+        required: true
+        schema:
+          $ref: '#/definitions/controller.ChangePasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Change user password
+      tags:
+      - Users
 securityDefinitions:
   BearerAuth:
     in: header

--- a/helper
+++ b/helper
@@ -2,6 +2,17 @@
 
 # Helper Script for Managing the Go Application
 
+# Function to check if port 8999 is in use
+check_port() {
+    echo "Checking port 8999..."
+    if command -v lsof >/dev/null 2>&1; then
+        sudo lsof -i :8999
+    else
+        echo "lsof is not installed. Please install it first:"
+        echo "sudo apt-get install lsof"
+    fi
+}
+
 # Function to run the main application
 run_main() {
     echo "Running the main application..."
@@ -85,7 +96,7 @@ usage() {
     echo "  npm-test    javascript test"
     echo "  push-docker push to docker "
     echo "  all         Run all build/run commands"
-
+    echo "  port        Check what process is using port 8999"
     echo "  test        Run tests"
     echo "  help        Display this help message"
 }
@@ -127,6 +138,9 @@ case "$1" in
         ;;
     test)
         run_tests
+        ;;
+    port)
+        check_port
         ;;
     all)
         run_npm_build

--- a/internal/adapters/controller/user.go
+++ b/internal/adapters/controller/user.go
@@ -3,7 +3,10 @@ package controller
 import (
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/robstave/meowmorize/internal/domain/types"
 )
 
@@ -26,6 +29,13 @@ func (hc *MeowController) AdminGetAllUsers(c echo.Context) error {
 	return c.JSON(http.StatusOK, users)
 }
 
+// AdminCreateUserRequest represents the payload for creating a user
+type AdminCreateUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
 // AdminCreateUser creates a new user
 // @Summary Create user
 // @Description Create a new user (admin only)
@@ -33,17 +43,34 @@ func (hc *MeowController) AdminGetAllUsers(c echo.Context) error {
 // @Accept json
 // @Produce json
 // @Security BearerAuth
-// @Param user body types.User true "User to create"
+// @Param user body AdminCreateUserRequest true "User to create"
 // @Success 201 {object} types.User
 // @Failure 400 {object} map[string]string
 // @Failure 403 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /admin/users [post]
 func (hc *MeowController) AdminCreateUser(c echo.Context) error {
-	var user types.User
-	if err := c.Bind(&user); err != nil {
+	var req AdminCreateUserRequest
+	if err := c.Bind(&req); err != nil {
 		hc.logger.Error("failed to bind user", "error", err)
 		return c.JSON(http.StatusBadRequest, echo.Map{"message": "invalid user payload"})
+	}
+
+	if req.Role == "" {
+		req.Role = "user"
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		hc.logger.Error("failed to hash password", "error", err)
+		return c.JSON(http.StatusInternalServerError, echo.Map{"message": "failed to create user"})
+	}
+
+	user := types.User{
+		ID:       uuid.New().String(),
+		Username: req.Username,
+		Password: string(hashedPassword),
+		Role:     req.Role,
 	}
 
 	if err := hc.service.CreateUser(user); err != nil {

--- a/internal/adapters/repositories/mocks/user_repository.go
+++ b/internal/adapters/repositories/mocks/user_repository.go
@@ -87,6 +87,20 @@ func (_m *UserRepository) GetUserByUsername(username string) (*types.User, error
 	return r0, r1
 }
 
+// UpdateUserPassword provides a mock function with given fields: userID, password
+func (_m *UserRepository) UpdateUserPassword(userID string, password string) error {
+	ret := _m.Called(userID, password)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(userID, password)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewUserRepository interface {
 	mock.TestingT
 	Cleanup(func())

--- a/internal/adapters/repositories/user.go
+++ b/internal/adapters/repositories/user.go
@@ -13,6 +13,7 @@ type UserRepository interface {
 	CreateUser(user types.User) error
 	GetAllUsers() ([]types.User, error)
 	DeleteUser(userID string) error
+	UpdateUserPassword(userID string, password string) error
 }
 
 type UserRepositorySQLite struct {
@@ -44,4 +45,8 @@ func (r *UserRepositorySQLite) GetAllUsers() ([]types.User, error) {
 
 func (r *UserRepositorySQLite) DeleteUser(userID string) error {
 	return r.db.Delete(&types.User{}, "id = ?", userID).Error
+}
+
+func (r *UserRepositorySQLite) UpdateUserPassword(userID string, password string) error {
+	return r.db.Model(&types.User{}).Where("id = ?", userID).Update("password", password).Error
 }

--- a/internal/domain/mocks/meow_domain.go
+++ b/internal/domain/mocks/meow_domain.go
@@ -555,6 +555,20 @@ func (_m *MeowDomain) UpdateDeck(deck types.Deck) error {
 	return r0
 }
 
+// UpdateUserPassword provides a mock function with given fields: userID, password
+func (_m *MeowDomain) UpdateUserPassword(userID string, password string) error {
+	ret := _m.Called(userID, password)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(userID, password)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewMeowDomain interface {
 	mock.TestingT
 	Cleanup(func())

--- a/internal/domain/service.go
+++ b/internal/domain/service.go
@@ -57,6 +57,7 @@ type MeowDomain interface {
 	CreateUser(user types.User) error
 	GetAllUsers() ([]types.User, error)
 	DeleteUser(userID string) error
+	UpdateUserPassword(userID string, password string) error
 	SeedUser() error
 
 	GetSessionLogsBySessionID(sessionID string) ([]types.SessionLog, error)

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -3,6 +3,7 @@ package domain
 
 import (
 	"github.com/robstave/meowmorize/internal/domain/types"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Implement the methods
@@ -20,4 +21,12 @@ func (s *Service) GetAllUsers() ([]types.User, error) {
 
 func (s *Service) DeleteUser(userID string) error {
 	return s.userRepo.DeleteUser(userID)
+}
+
+func (s *Service) UpdateUserPassword(userID string, password string) error {
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	return s.userRepo.UpdateUserPassword(userID, string(hashedPassword))
 }

--- a/meowmorize-frontend/src/App.js
+++ b/meowmorize-frontend/src/App.js
@@ -12,6 +12,7 @@ import DeckPage from './pages/DeckPage'; //
 import CardPage from './pages/CardPage'; //
 import CardForm from './pages/CardForm'; //
 import UserManagement from './pages/UserManagement'; // Import UserManagement page
+import ChangePassword from './pages/ChangePassword';
 import { lightTheme, darkTheme } from './theme';
 import LoginPage from './pages/LoginPage'; // Import LoginPage
 import { AuthContext } from './context/AuthContext'; // Import AuthContext
@@ -58,16 +59,17 @@ function App() {
           <Route path="/decks/:deckId/card/:id" element={auth.token ? <CardPage /> : <Navigate to="/login" />} />
           <Route path="/card-form" element={auth.token ? <CardForm /> : <Navigate to="/login" />} />
           <Route path="/card-form/:id" element={auth.token ? <CardForm /> : <Navigate to="/login" />} />
-          <Route 
-            path="/admin/users" 
+          <Route
+            path="/admin/users"
             element={
               auth.token && auth.user?.role === 'admin' ? (
                 <UserManagement />
               ) : (
                 <Navigate to="/" />
               )
-            } 
+            }
           />
+          <Route path="/password" element={auth.token ? <ChangePassword /> : <Navigate to="/login" />} />
 
 
           {/* Route to handle Swagger UI redirect */}

--- a/meowmorize-frontend/src/components/Navbar.jsx
+++ b/meowmorize-frontend/src/components/Navbar.jsx
@@ -8,10 +8,13 @@ import {
   MenuItem,
   Snackbar,
   IconButton,
+  Badge
 } from '@mui/material';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import Logo from '../logo512.png'; // Adjust the path if necessary
 import MenuIcon from '@mui/icons-material/Menu';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import StarIcon from '@mui/icons-material/Star';
 
 import { createEmptyDeck, fetchDecks } from '../services/api';
 
@@ -33,6 +36,8 @@ const Navbar = () => {
   const { auth, logout } = useContext(AuthContext);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
+  const [userAnchorEl, setUserAnchorEl] = React.useState(null);
+  const userMenuOpen = Boolean(userAnchorEl);
 
   const [collapseDialogOpen, setCollapseDialogOpen] = useState(false);
 
@@ -72,9 +77,22 @@ const Navbar = () => {
     setAnchorEl(event.currentTarget);
   };
 
+  const handleUserMenuOpen = (event) => {
+    setUserAnchorEl(event.currentTarget);
+  };
+
+  const handleChangePassword = () => {
+    navigate('/password');
+    handleUserMenuClose();
+  };
+
   // Handler to close the dropdown menu
   const handleMenuClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleUserMenuClose = () => {
+    setUserAnchorEl(null);
   };
 
   // Handler for logout
@@ -221,6 +239,29 @@ const Navbar = () => {
           }
           label="Dark Mode"
         />
+
+        {auth.token && (
+          <>
+            <IconButton color="inherit" onClick={handleUserMenuOpen}>
+              <Badge
+                overlap="circular"
+                badgeContent={auth.user?.role === 'admin' ? (
+                  <StarIcon sx={{ fontSize: '0.8rem', color: 'gold' }} />
+                ) : null}
+              >
+                <AccountCircleIcon />
+              </Badge>
+            </IconButton>
+            <Menu
+              anchorEl={userAnchorEl}
+              open={userMenuOpen}
+              onClose={handleUserMenuClose}
+              MenuListProps={{ 'aria-labelledby': 'user-menu-button' }}
+            >
+              <MenuItem onClick={handleChangePassword}>Change Password</MenuItem>
+            </Menu>
+          </>
+        )}
 
         {/* Authentication Buttons */}
         {!auth.token ? (

--- a/meowmorize-frontend/src/pages/ChangePassword.jsx
+++ b/meowmorize-frontend/src/pages/ChangePassword.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Container, Typography, TextField, Button, Box, Snackbar, Alert } from '@mui/material';
+import { changePassword } from '../services/api';
+
+const ChangePassword = () => {
+  const [passwordData, setPasswordData] = useState({ password: '', confirm: '' });
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+
+  const handleChange = (e) => {
+    setPasswordData({ ...passwordData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (passwordData.password !== passwordData.confirm) {
+      setSnackbar({ open: true, message: 'Passwords do not match', severity: 'error' });
+      return;
+    }
+    try {
+      await changePassword(passwordData.password);
+      setSnackbar({ open: true, message: 'Password updated', severity: 'success' });
+      setPasswordData({ password: '', confirm: '' });
+    } catch (err) {
+      setSnackbar({ open: true, message: 'Failed to update password', severity: 'error' });
+    }
+  };
+
+  const handleClose = () => {
+    setSnackbar({ ...snackbar, open: false });
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Typography variant="h4" gutterBottom>
+        Change Password
+      </Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <TextField
+          label="New Password"
+          name="password"
+          type="password"
+          value={passwordData.password}
+          onChange={handleChange}
+          required
+        />
+        <TextField
+          label="Confirm Password"
+          name="confirm"
+          type="password"
+          value={passwordData.confirm}
+          onChange={handleChange}
+          required
+        />
+        <Button variant="contained" color="primary" type="submit">
+          Update Password
+        </Button>
+      </Box>
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Container>
+  );
+};
+
+export default ChangePassword;

--- a/meowmorize-frontend/src/pages/UserManagement.jsx
+++ b/meowmorize-frontend/src/pages/UserManagement.jsx
@@ -81,6 +81,7 @@ const UserManagement = () => {
   };
 
   const handleDeleteUser = async (userId, username) => {
+    console.log(`Deleting user with ID: ${userId} and username: ${username}`);
     if (window.confirm(`Are you sure you want to delete user "${username}"?`)) {
       try {
         await deleteUser(userId);

--- a/meowmorize-frontend/src/services/api.js
+++ b/meowmorize-frontend/src/services/api.js
@@ -315,4 +315,13 @@ export const deleteUser = async (userId) => {
   }
 };
 
+export const changePassword = async (password) => {
+  try {
+    const response = await api.put('/user/password', { password });
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- support password change API and service
- add user menu endpoint on backend
- show account icon with admin badge
- allow password change from UI

## Testing
- `go test ./...` *(fails: Forbidden - proxy.golang.org)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc5813bb4832ebaf623f1726cb720