### PR TITLE
Add env-based JWT secret handling

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,3 +7,5 @@ PORT=8999
 # Gemini API configuration
 GOOGLE_API_KEY=your-api-key-here
 GOOGLE_MODEL=gemini-1.5-pro
+# Authentication
+JWT_SECRET=change-me

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Ensure all dependencies are installed and run the following commands using the h
 - **Database Reset**: To start fresh, simply delete the `meowmorize.db` file located at the root directory and restart the backend application.
 - **Ports Configuration**: The frontend listens on port `8999` as specified in the `.env` file. Ensure this port is available or adjust the configuration as needed.
 - **User Authentication**: The application initializes with a default user. Customize the username, password, and role using the `DEFAULT_USER_USERNAME`, `DEFAULT_USER_PASSWORD`, and `DEFAULT_USER_ROLE` environment variables (role defaults to `admin`).
+- **JWT Secret**: Set the `JWT_SECRET` environment variable to the secret used for signing JWT tokens. The application will exit if this variable is missing.
 
 ## License
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -78,6 +78,14 @@ func main() {
 	// Initialize Service
 	service := domain.NewService(slogger, deckRepo, cardRepo, userRepo, sessionLogRepo, llmRepo)
 
+	// Read JWT secret from environment
+	jwtSecret := os.Getenv("JWT_SECRET")
+	if jwtSecret == "" {
+		slogger.Error("JWT_SECRET environment variable is required")
+		log.Fatal("JWT_SECRET environment variable is required")
+	}
+	controller.InitJWTSecret(jwtSecret)
+
 	// Initialize Controller
 	meowController := controller.NewMeowController(service, slogger)
 

--- a/internal/adapters/controller/auth.go
+++ b/internal/adapters/controller/auth.go
@@ -10,9 +10,15 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// JWTSecret is the secret key used to sign JWT tokens.
-// In a production environment, ensure this is secure and not hard-coded.
-var JWTSecret = []byte("your_secret_key")
+// JWTSecret is the secret key used to sign JWT tokens. It is initialized at
+// startup using InitJWTSecret. In a production environment, ensure this value
+// is stored securely and not hard-coded.
+var JWTSecret []byte
+
+// InitJWTSecret sets the JWT secret used for signing tokens.
+func InitJWTSecret(secret string) {
+	JWTSecret = []byte(secret)
+}
 
 // LoginRequest represents the expected payload for login
 type LoginRequest struct {


### PR DESCRIPTION
## Summary
- wire JWT_SECRET from environment into main
- load JWT secret in controller instead of hardcoding
- document JWT_SECRET in README and env template

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685455a92d14832eba9b668f6a6b7079