### PR TITLE
Add markdown sanitization

### DIFF
--- a/meowmorize-frontend/package.json
+++ b/meowmorize-frontend/package.json
@@ -24,6 +24,7 @@
     "react-scripts": "^5.0.1",
     "recharts": "^2.14.1",
     "rehype-highlight": "^7.0.2",
+    "rehype-sanitize": "^5.0.1",
     "remark-gfm": "^4.0.0",
     "seedrandom": "^3.0.5",
     "web-vitals": "^2.1.4"

--- a/meowmorize-frontend/src/pages/CardPage.jsx
+++ b/meowmorize-frontend/src/pages/CardPage.jsx
@@ -26,6 +26,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import rehypeSanitize from 'rehype-sanitize';
 
 // Components
 import PieStatusChart from '../components/CatStatusChart';
@@ -284,7 +285,7 @@ const CardPage = () => {
             <Typography variant="h6" gutterBottom>
               {showFront ? 'Front' : 'Back'}
             </Typography>
-            <ReactMarkdown rehypePlugins={[rehypeHighlight]} remarkPlugins={[remarkGfm]}>
+            <ReactMarkdown rehypePlugins={[rehypeHighlight, rehypeSanitize]} remarkPlugins={[remarkGfm]}>
               {showFront ? card.front.text : card.back.text}
             </ReactMarkdown>
           </Box>
@@ -392,7 +393,7 @@ const CardPage = () => {
             Explanation
           </Typography>
           <Typography variant="body1" component="div">
-            <ReactMarkdown rehypePlugins={[rehypeHighlight]} remarkPlugins={[remarkGfm]}>
+            <ReactMarkdown rehypePlugins={[rehypeHighlight, rehypeSanitize]} remarkPlugins={[remarkGfm]}>
               {explanation}
             </ReactMarkdown>
           </Typography>

--- a/meowmorize-frontend/src/pages/ImportPage.jsx
+++ b/meowmorize-frontend/src/pages/ImportPage.jsx
@@ -18,6 +18,7 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import MuiAlert from '@mui/material/Alert';
 import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
 import {
   importDeck,
   createEmptyDeck,
@@ -213,7 +214,9 @@ const ImportPage = () => {
             <Typography>Markdown</Typography>
           </AccordionSummary>
           <AccordionDetails>
-            <ReactMarkdown>{markdownInstructions}</ReactMarkdown>
+            <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+              {markdownInstructions}
+            </ReactMarkdown>
           </AccordionDetails>
         </Accordion>
         <Accordion>
@@ -221,7 +224,9 @@ const ImportPage = () => {
             <Typography>JSON</Typography>
           </AccordionSummary>
           <AccordionDetails>
-            <ReactMarkdown>{jsonInstructions}</ReactMarkdown>
+            <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+              {jsonInstructions}
+            </ReactMarkdown>
           </AccordionDetails>
         </Accordion>
       </Box>


### PR DESCRIPTION
## Summary
- install rehype-sanitize dependency
- use rehype-sanitize with ReactMarkdown in CardPage and ImportPage

## Testing
- `./helper test` *(fails: Get https://proxy.golang.org/... Forbidden)*
- `./helper npm-test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854559b45d0832ebf8d4a06ec686eb0