### PR TITLE
Handle missing auth tokens

### DIFF
--- a/internal/adapters/controller/card-stats.go
+++ b/internal/adapters/controller/card-stats.go
@@ -40,7 +40,7 @@ func (c *MeowController) UpdateCardStats(ctx echo.Context) error {
 	userID, err := getUserIDFromContext(ctx)
 	if err != nil {
 		c.logger.Error("Failed to extract user id from token", "error", err)
-		userID = "demo_user"
+		return ctx.JSON(http.StatusUnauthorized, echo.Map{"message": "unauthorized"})
 	}
 
 	// Optional: Add validation here if using a validation library

--- a/internal/adapters/controller/session.go
+++ b/internal/adapters/controller/session.go
@@ -39,7 +39,7 @@ func (hc *MeowController) StartSession(c echo.Context) error {
 	userID, err := getUserIDFromContext(c)
 	if err != nil {
 		hc.logger.Error("Failed to extract user id from token", "error", err)
-		userID = "demo_user"
+		return c.JSON(http.StatusUnauthorized, echo.Map{"message": "unauthorized"})
 	}
 
 	// Optional: Add validation here if using a validation library


### PR DESCRIPTION
## Summary
- return a 401 response if token parsing fails when starting a session
- return a 401 response if token parsing fails when updating card stats

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68545589f774832e813443ac67908be4