### PR TITLE
Fix deck validation in card edit

### DIFF
--- a/meowmorize-frontend/src/pages/CardForm.jsx
+++ b/meowmorize-frontend/src/pages/CardForm.jsx
@@ -104,7 +104,7 @@ const CardForm = () => {
         e.preventDefault();
 
         // Basic validation
-        if (!formData.deck_id) {
+        if (!isEditMode && !formData.deck_id) {
             setError('Deck ID is required.');
             return;
         }


### PR DESCRIPTION
## Summary
- allow editing a card when `deck_id` is not provided

## Testing
- `./helper npm-test` *(fails: react-scripts not found)*
- `./helper test` *(fails to fetch dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6861a85346b0832e8a3edd999557785a