### PR TITLE
Add card ownership and optional backfill

### DIFF
--- a/internal/adapters/controller/card.go
+++ b/internal/adapters/controller/card.go
@@ -118,8 +118,11 @@ func (c *MeowController) CreateCard(ctx echo.Context) error {
 		Link: req.Link,
 	}
 
+	// Set card owner
+	newCard.UserID = userID
+
 	// Call the service to create the card
-	ccard, err := c.service.CreateCard(newCard, deckID)
+	ccard, err := c.service.CreateCard(newCard, deckID, userID)
 	if err != nil {
 		c.logger.Error("Failed to create card", "error", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create card")

--- a/internal/adapters/controller/import.go
+++ b/internal/adapters/controller/import.go
@@ -66,6 +66,11 @@ func (hc *MeowController) ImportDeck(c echo.Context) error {
 	// Set the deck owner from the JWT (override any owner info in the JSON).
 	deck.UserID = userID
 
+	// Ensure each card is owned by the importing user
+	for i := range deck.Cards {
+		deck.Cards[i].UserID = userID
+	}
+
 	// Since the many-to-many relation is managed via a join table, there's no need to assign a DeckID to each card.
 	// The association will be saved automatically via deck.Cards in the CreateDeck service method.
 

--- a/internal/domain/cards.go
+++ b/internal/domain/cards.go
@@ -27,11 +27,12 @@ func (s *Service) GetCardByID(cardID string) (*types.Card, error) {
 	return card, nil
 }
 
-func (s *Service) CreateCard(card types.Card, deckID string) (*types.Card, error) {
+func (s *Service) CreateCard(card types.Card, deckID string, userID string) (*types.Card, error) {
 	// Create the card in the cards table
 	if card.ID == "" {
 		card.ID = uuid.New().String()
 	}
+	card.UserID = userID
 	if err := s.cardRepo.CreateCard(card); err != nil {
 		return nil, err
 	}

--- a/internal/domain/cards_test.go
+++ b/internal/domain/cards_test.go
@@ -86,7 +86,7 @@ func TestCardService_CreateCard_Success(t *testing.T) {
 	dr.On("AddCardToDeck", "deck1", mock.AnythingOfType("types.Card")).Return(nil)
 
 	dm := NewService(logger.InitializeLogger(), dr, cardRepo, userRepo, sessionRepo, llmRepo)
-	createdCard, err := dm.CreateCard(newCard, "deck1")
+	createdCard, err := dm.CreateCard(newCard, "deck1", "user1")
 	assert.NoError(t, err)
 	assert.NotNil(t, createdCard)
 	// Verify that a new ID was assigned.

--- a/internal/domain/mocks/meow_domain.go
+++ b/internal/domain/mocks/meow_domain.go
@@ -91,13 +91,13 @@ func (_m *MeowDomain) CollapseDecks(targetDeckID string, sourceDeckID string) er
 	return r0
 }
 
-// CreateCard provides a mock function with given fields: card, deckID
-func (_m *MeowDomain) CreateCard(card types.Card, deckID string) (*types.Card, error) {
-	ret := _m.Called(card, deckID)
+// CreateCard provides a mock function with given fields: card, deckID, userID
+func (_m *MeowDomain) CreateCard(card types.Card, deckID string, userID string) (*types.Card, error) {
+	ret := _m.Called(card, deckID, userID)
 
 	var r0 *types.Card
-	if rf, ok := ret.Get(0).(func(types.Card, string) *types.Card); ok {
-		r0 = rf(card, deckID)
+	if rf, ok := ret.Get(0).(func(types.Card, string, string) *types.Card); ok {
+		r0 = rf(card, deckID, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.Card)
@@ -105,8 +105,8 @@ func (_m *MeowDomain) CreateCard(card types.Card, deckID string) (*types.Card, e
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(types.Card, string) error); ok {
-		r1 = rf(card, deckID)
+	if rf, ok := ret.Get(1).(func(types.Card, string, string) error); ok {
+		r1 = rf(card, deckID, userID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/domain/service.go
+++ b/internal/domain/service.go
@@ -32,7 +32,7 @@ type MeowDomain interface {
 
 	// Card methods
 	GetCardByID(cardID string) (*types.Card, error)
-	CreateCard(card types.Card, deckID string) (*types.Card, error)
+	CreateCard(card types.Card, deckID string, userID string) (*types.Card, error)
 	UpdateCard(card types.Card) error
 	DeleteCardByID(cardID string) error
 	CloneCardToDeck(cardID string, targetDeckID string) (*types.Card, error)
@@ -90,4 +90,17 @@ func NewService(logger *slog.Logger,
 	}
 
 	return service
+}
+
+// backfillCardOwners sets the user_id on any cards within the deck that do not have an owner
+func (s *Service) backfillCardOwners(deck types.Deck, userID string) error {
+	for _, card := range deck.Cards {
+		if card.UserID == "" {
+			card.UserID = userID
+			if err := s.cardRepo.UpdateCard(card); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -26,6 +26,11 @@ func (s *Service) StartSession(deckID string, count int, method types.SessionMet
 		return err
 	}
 
+	// backfill any cards without an owner
+	if err := s.backfillCardOwners(deck, userID); err != nil {
+		s.logger.Error("failed to backfill card owners", "error", err)
+	}
+
 	// Update LastAccessed
 	deck.LastAccessed = time.Now()
 	if err := s.deckRepo.UpdateDeck(deck); err != nil {

--- a/internal/domain/types/card.go
+++ b/internal/domain/types/card.go
@@ -6,6 +6,7 @@ type Card struct {
 	ID         string    `gorm:"primaryKey" json:"id"`
 	Front      CardFront `gorm:"embedded;embeddedPrefix:front_" json:"front"`
 	Back       CardBack  `gorm:"embedded;embeddedPrefix:back_" json:"back"`
+	UserID     string    `gorm:"not null" json:"user_id"`
 	Link       string    `gorm:"type:text" json:"link"`
 	PassCount  int       `gorm:"default:0" json:"pass_count"`
 	FailCount  int       `gorm:"default:0" json:"fail_count"`


### PR DESCRIPTION
## Summary
- add `UserID` to `Card` model
- set card owner when decks are imported or cards created
- add feature flag `BACKFILL_CARD_USERID` to update card owners when starting sessions
- implement backfill helper and update tests
- remove feature flag, always backfill card owners on session start

## Testing
- `go test ./...` *(fails: unable to access external modules)*

------
https://chatgpt.com/codex/tasks/task_e_68675e949fb8832e8ceef889b1f8ae6c